### PR TITLE
Fix login issue: remove disabled button condition and password state 

### DIFF
--- a/patches/@graphcommerce+magento-customer+9.0.4.patch
+++ b/patches/@graphcommerce+magento-customer+9.0.4.patch
@@ -1900,30 +1900,25 @@ index 9a27189..c8fe6c7 100644
 +import { Box, CircularProgress, FormControl, Link } from '@mui/material'
  import { useSignInForm } from '../../hooks/useSignInForm'
  import { ApolloCustomerErrorAlert } from '../ApolloCustomerError/ApolloCustomerErrorAlert'
-+import { useState } from 'react'
  
  export type SignInFormProps = {
    email?: string
-@@ -18,6 +19,8 @@ export type SignInFormProps = {
+@@ -18,6 +19,6 @@ export type SignInFormProps = {
  
  export function SignInForm(props: SignInFormProps) {
    const { email, sx, setError, clearErrors } = props
-+  const [password, setpassword] = useState<string>("")
-+  const [hasTyped, setHasTyped] = useState(false);
  
    const form = useSignInForm({
      email,
-@@ -29,7 +32,8 @@ export function SignInForm(props: SignInFormProps) {
+@@ -29,7 +32,7 @@ export function SignInForm(props: SignInFormProps) {
        }
        // eslint-disable-next-line @typescript-eslint/no-use-before-define
        clearErrors()
--      return variables
-+      setHasTyped(false);
-+      return { ...variables, password }
+       return variables
      },
    })
  
-@@ -37,14 +41,22 @@ export function SignInForm(props: SignInFormProps) {
+@@ -37,14 +41,18 @@ export function SignInForm(props: SignInFormProps) {
    const [remainingError, authError] = graphqlErrorByCategory({
      category: 'graphql-authentication',
      error,
@@ -1937,12 +1932,8 @@ index 9a27189..c8fe6c7 100644
      <Box component='form' onSubmit={submitHandler} noValidate sx={sx}>
        <FormRow sx={{ gridTemplateColumns: 'none' }}>
          <PasswordElement
-+          onChange={(e) => {
-+            setHasTyped(true);
-+            setpassword(e.target.value)
-+            if (error) {
-+              form.clearErrors()
-+            }
++          onChange={() => {
++            if (error) form.clearErrors()
 +          }}
            variant='outlined'
            error={!!formState.errors.password || !!authError}
@@ -1952,7 +1943,7 @@ index 9a27189..c8fe6c7 100644
            required={required.password}
            disabled={formState.isSubmitting}
 -          helperText={!!formState.errors.password || authError?.message}
-+          helperText={formState.errors.password?.message || (hasTyped ? null : authError?.message)}
++          helperText={formState.errors.password?.message || authError?.message}
            InputProps={{
              endAdornment: (
 -              <Link href='/account/forgot-password' underline='hover' sx={{ whiteSpace: 'nowrap' }}>
@@ -1960,13 +1951,12 @@ index 9a27189..c8fe6c7 100644
                  <Trans id='Forgot password?' />
                </Link>
              ),
-@@ -74,10 +86,34 @@ export function SignInForm(props: SignInFormProps) {
+@@ -74,10 +86,33 @@ export function SignInForm(props: SignInFormProps) {
              type='submit'
              loading={formState.isSubmitting}
              color='primary'
 -            variant='pill'
 +            // variant='pill'
-+            disabled={formState.isSubmitting || !formState.isValid}
              size='large'
 +            sx={{
 +              backgroundColor: (theme: any) => theme.palette.custom.main,

--- a/patches/@graphcommerce+next-ui+9.0.4.patch
+++ b/patches/@graphcommerce+next-ui+9.0.4.patch
@@ -843,7 +843,7 @@ index 30fc40b..5d190eb 100644
 +  const { loggedIn, createdAt, customer_access_token_lifetime } = useCustomerSession()
 +
 +  useEffect(() => {
-+    if (loggedIn && createdAt && customer_access_token_lifetime) {
++    if (loggedIn && createdAt && customer_access_token_lifetime && customer_access_token_lifetime > 0) {
 +      const checkSession = () => {
 +        const loginTime = new Date(createdAt).getTime()
 +        const expiryTime = loginTime + customer_access_token_lifetime * 60 * 60 * 1000


### PR DESCRIPTION
Root causes fixed:
1. SignInForm: Removed 'disabled={!formState.isValid}' from submit button. With react-hook-form default mode (onSubmit), formState.isValid is always false on initial render, permanently disabling the button and preventing users from logging in by clicking.

2. SignInForm: Removed local password state override in onBeforeSubmit. The patch was using a separate useState to track the password and override variables.password, which breaks on browser autofill (onChange never fires, leaving local state as empty string, causing authentication failure). Reverted to using form variables directly.

3. SignInForm: Simplified PasswordElement onChange to only clear errors, removing stale hasTyped/setpassword state references.

4. SignInForm: Fixed helperText to show authError directly instead of conditionally hiding it based on removed hasTyped state.

5. LayoutDefault: Added customer_access_token_lifetime > 0 guard to session expiry check to prevent immediate sign-out when lifetime is 0.