### PR TITLE
Fix meshrc: add schemaHeaders for introspection, retry and timeout

### DIFF
--- a/.meshrc.yml
+++ b/.meshrc.yml
@@ -5,7 +5,10 @@ sources:
         endpoint: 'https://srv900162.hstgr.cloud/graphql'
         useGETForQueries: true
         batch: false
-          
+        retry: 3
+        timeout: 30000
+        schemaHeaders:
+          Store: 'default'
         operationHeaders:
           Store: 'default'
           Authorization: '{context.headers.authorization}'


### PR DESCRIPTION
Fix:
- Add schemaHeaders.Store: 'default' (static, no context interpolation needed)
- Add retry: 3 for transient network failures during Vercel build
- Add timeout: 30000 ms to avoid hanging builds
- Remove stray blank line in YAML